### PR TITLE
fix: railway volume permissions, document image renderer, bump release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,23 @@ FROM grafana/grafana-oss:${VERSION}
 
 ENV \
     GF_INSTALL_PLUGINS=grafana-piechart-panel,grafana-worldmap-panel,grafana-clock-panel,grafana-simple-json-datasource
+
+# The entrypoint needs root to fix ownership of the Railway volume before
+# handing over to UID 472. Installing packages requires root as well.
+USER root
+
+# su-exec on the Alpine variant (default), gosu on the -ubuntu variant. Both
+# replace the process instead of forking, so no root process reaches runtime.
+RUN if command -v apk >/dev/null 2>&1; then \
+        apk add --no-cache su-exec; \
+    else \
+        apt-get update && \
+        apt-get install -y --no-install-recommends gosu && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ The recursive `chown` only runs when the mount root is still misowned, so it
 costs one pass on the first boot after attaching a volume and nothing on
 subsequent restarts.
 
+## 🖼️ Image rendering (`grafana-image-renderer`)
+
+Adding `grafana-image-renderer` to `GF_INSTALL_PLUGINS` does **not** work on the
+default image and fails at startup with `exit status 127`:
+
+```log
+Error: ✗ *rendering.RenderingService run error: Unrecognized remote plugin message
+```
+
+The plugin binary is linked against glibc, while `grafana/grafana-oss` is
+Alpine-based and ships musl. Grafana closed the corresponding upstream report
+([grafana-image-renderer#475](https://github.com/grafana/grafana-image-renderer/issues/475))
+as *not planned*, so there is no fix to wait for. Two options work:
+
+| Option | How | Trade-off |
+| --- | --- | --- |
+| Ubuntu image variant | Set `VERSION=latest-ubuntu` (build arg / Railway variable) | glibc-compatible, single service — but a noticeably larger image and rendering competes with Grafana for the same CPU/memory |
+| Separate renderer service | Deploy `grafana/grafana-image-renderer` as its own Railway service, then point Grafana at it via `GF_RENDERING_SERVER_URL=http://<service>:8081/render` and `GF_RENDERING_CALLBACK_URL=http://<grafana-service>:3000/` | Scales independently and keeps Chromium out of the Grafana container — but a second service to run and pay for |
+
+For anything beyond occasional PDF or panel exports, the separate service is the
+better fit: rendering is CPU- and memory-spiky, and isolating it keeps those
+spikes away from the dashboards themselves.
+
 ## 🐍 How to Deploy
 
 1. Click Deploy on Railway and setup your credentials in the environment variables

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ Long-form template copy for Railway (description / **Deploy and Host** sections)
 * Keep healthcheck path at `/api/health`
 * Restrict plugin list in `GF_INSTALL_PLUGINS` to required plugins only
 
+## 💾 Volume permissions
+
+Railway mounts volumes as `root:root`, while the upstream Grafana image runs as
+UID 472. A plain `grafana/grafana-oss` deployment therefore fails on first boot
+with:
+
+```log
+mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied
+GF_PATHS_DATA='/var/lib/grafana' is not writable.
+```
+
+This template handles it in [`docker-entrypoint.sh`](docker-entrypoint.sh): the
+container starts as root, takes ownership of the mount, and then `exec`s into
+UID 472. Since it is an `exec` rather than a fork, no root process survives into
+runtime — the Grafana process itself stays unprivileged.
+
+You do **not** need to set `RAILWAY_RUN_UID=0`. That variable is the common
+workaround for this class of error, but it leaves Grafana running as root for the
+entire lifetime of the container.
+
+The recursive `chown` only runs when the mount root is still misowned, so it
+costs one pass on the first boot after attaching a volume and nothing on
+subsequent restarts.
+
 ## 🐍 How to Deploy
 
 1. Click Deploy on Railway and setup your credentials in the environment variables

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Entrypoint wrapper for Railway deployments.
+#
+# Railway mounts volumes as root:root, while the upstream Grafana image runs as
+# UID 472. Without this wrapper, Grafana cannot write to a mounted
+# /var/lib/grafana and aborts with "GF_PATHS_DATA is not writable".
+#
+# The container therefore starts as root, fixes ownership of the mount, and then
+# hands over to UID 472 via exec. Because it is an exec (not a fork), no root
+# process survives into runtime -- Grafana itself never runs privileged.
+#
+set -eu
+
+GF_UID=472
+GF_GID=0
+
+GF_PATHS_DATA="${GF_PATHS_DATA:-/var/lib/grafana}"
+GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS:-${GF_PATHS_DATA}/plugins}"
+
+# Railway injects PORT; Grafana expects GF_SERVER_HTTP_PORT. An explicitly
+# configured GF_SERVER_HTTP_PORT always wins.
+GF_SERVER_HTTP_PORT="${GF_SERVER_HTTP_PORT:-${PORT:-3000}}"
+export GF_SERVER_HTTP_PORT
+
+# Pick whichever privilege-dropping helper the base image variant provides:
+# su-exec on Alpine (default), gosu on the -ubuntu variant.
+drop_privileges() {
+    if command -v su-exec >/dev/null 2>&1; then
+        exec su-exec "${GF_UID}:${GF_GID}" "$@"
+    elif command -v gosu >/dev/null 2>&1; then
+        exec gosu "${GF_UID}:${GF_GID}" "$@"
+    fi
+
+    echo "entrypoint: neither su-exec nor gosu found, cannot drop privileges" >&2
+    exit 1
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    # Already unprivileged (e.g. a runtime that ignores the image USER).
+    # Nothing to fix up -- if the volume is misowned, Grafana will report it.
+    exec "$@"
+fi
+
+mkdir -p "${GF_PATHS_DATA}" "${GF_PATHS_PLUGINS}"
+
+# chown -R on every boot would rewrite the whole volume, which grows expensive
+# as dashboards and plugins accumulate. The recursive pass only runs when the
+# mount root is still misowned, i.e. on the first boot after a volume is added.
+if [ "$(stat -c %u "${GF_PATHS_DATA}")" != "${GF_UID}" ]; then
+    echo "entrypoint: taking ownership of ${GF_PATHS_DATA} for uid ${GF_UID}"
+    chown -R "${GF_UID}:${GF_GID}" "${GF_PATHS_DATA}"
+fi
+
+# Plugins may live outside GF_PATHS_DATA when GF_PATHS_PLUGINS is overridden.
+case "${GF_PATHS_PLUGINS}" in
+    "${GF_PATHS_DATA}"/*) ;;
+    *)
+        if [ "$(stat -c %u "${GF_PATHS_PLUGINS}")" != "${GF_UID}" ]; then
+            chown -R "${GF_UID}:${GF_GID}" "${GF_PATHS_PLUGINS}"
+        fi
+        ;;
+esac
+
+drop_privileges "$@"

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,8 @@
 builder = "DOCKERFILE"
 
 [deploy]
-startCommand = "sh -c 'export GF_SERVER_HTTP_PORT=${PORT:-3000}; /run.sh'"
+# No startCommand: the image entrypoint maps PORT to GF_SERVER_HTTP_PORT and
+# prepares the volume mount before starting Grafana. See docker-entrypoint.sh.
 healthcheckPath = "/api/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Addresses the three open issues in this repository.

## fix: Railway volume permissions (#4)

Railway mounts volumes as `root:root` while `grafana/grafana-oss` runs as UID 472, so every deployment with a volume on `/var/lib/grafana` aborted on first boot:

```log
mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied
GF_PATHS_DATA='/var/lib/grafana' is not writable.
```

Since `railway.toml` declares `requiredMountPath = "/var/lib/grafana"`, this was not an edge case — it affected every deployment from the template.

A wrapper entrypoint (`docker-entrypoint.sh`) now starts as root, takes ownership of the mount, and `exec`s into UID 472.

**Why not `RAILWAY_RUN_UID=0`?** That is the widely suggested workaround, but it leaves Grafana running as root for the container's entire lifetime. Because the entrypoint `exec`s rather than forks, no root process reaches runtime here — root exists only for the duration of the `chown`, and the Grafana process stays unprivileged.

Further details:

- The recursive `chown` is gated on the mount root still being misowned, so it costs one pass on the first boot after a volume is attached and nothing on subsequent restarts. A blind `chown -R` on every boot would get progressively slower as dashboards and plugins accumulate.
- The `PORT` → `GF_SERVER_HTTP_PORT` mapping moves out of the `railway.toml` `startCommand` and into the entrypoint, so the image behaves identically locally and on Railway. An explicitly configured `GF_SERVER_HTTP_PORT` still takes precedence.
- Both `su-exec` (Alpine, default) and `gosu` (`-ubuntu` variant) are supported, so the image-renderer workaround documented below keeps building.

## docs: image renderer incompatibility (#3)

`grafana-image-renderer` in `GF_INSTALL_PLUGINS` fails with `exit status 127`: the plugin binary is linked against glibc, while `grafana/grafana-oss` is Alpine-based and ships musl. Grafana closed the upstream report ([grafana-image-renderer#475](https://github.com/grafana/grafana-image-renderer/issues/475)) as *not planned*, so there is no fix to wait for.

The plugin was never in this template's default plugin list, so this is a documentation gap rather than a code defect. The README now records both working paths — the `-ubuntu` image variant and a separate renderer service — with their trade-offs.

## chore(deps): release-please-action v5 (#2)

The only breaking change in v5.0.0 is the Node 24 runtime, which `ubuntu-latest` provides. No configuration changes required.

## Testing

The entrypoint logic was verified against 8 cases using mocked `su-exec`/`gosu`/`run.sh` binaries: first boot with a root-owned volume, restart with an already-correct volume, `GF_SERVER_HTTP_PORT` precedence over `PORT`, the `PORT`-unset default, the `gosu` fallback path, a `GF_PATHS_PLUGINS` outside `GF_PATHS_DATA`, a clean exit 1 when no privilege-drop helper exists (rather than silently continuing as root), and the unprivileged path taking a direct `exec` with no `chown` attempt.

**Not verified:** no Docker daemon was available in the environment, so the image build (`apk add su-exec`, the `COPY`, the `ENTRYPOINT`/`CMD` wiring) and a real Grafana startup against a Railway volume have not been executed. That is the remaining check before merging — hence draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUu9gXjygwGweE4Hvb7Pvs)_