### PR TITLE
fix(security): remove committed .env with real-looking admin credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-PORT=3000
-VERSION=latest
-
-GF_DEFAULT_INSTANCE_NAME=my-instance
-GF_SECURITY_ADMIN_USER=yourusername
-GF_SECURITY_ADMIN_PASSWORD=yourpassword
-GF_INSTALL_PLUGINS=grafana-piechart-panel,grafana-worldmap-panel,grafana-clock-panel,grafana-simple-json-datasource
-GF_LOG_MODE=console

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+PORT=3000
+VERSION=latest
+
+GF_DEFAULT_INSTANCE_NAME=my-instance
+# Set this in the Railway dashboard as a generated secret
+GF_SECURITY_ADMIN_USER=
+# Set this in the Railway dashboard as a generated secret
+GF_SECURITY_ADMIN_PASSWORD=
+GF_INSTALL_PLUGINS=grafana-piechart-panel,grafana-worldmap-panel,grafana-clock-panel,grafana-simple-json-datasource
+GF_LOG_MODE=console


### PR DESCRIPTION
## Summary

- **Security-critical**: a real `.env` file was committed to the repo with `GF_SECURITY_ADMIN_USER=yourusername` / `GF_SECURITY_ADMIN_PASSWORD=yourpassword`. Even though these particular values are placeholder-ish, having an actual `.env` committed (rather than only an `.env.example`) invites real secrets to land there in future edits/copy-paste, and it's already gitignored going forward (`.gitignore` has `.env` / `.env.*`) which confirms it should never have been tracked. Deleted `.env` and added `.env.example` with the same variable names but admin user/password now point to `# Set this in the Railway dashboard as a generated secret`.
- **Repo cleanliness — `version.txt`**: checked whether anything references it. `release-please-config.json` uses `"release-type": "simple"`, whose strategy is specifically designed to track/bump the version in a root `version.txt` file. So it **is** functionally used by the existing release-please automation — **not deleted**.
- **Changelog**: already present and correctly maintained — no action needed.

## Not solvable in code

- The real Grafana admin username/password for the deployed Railway environment must be set as Railway-generated secrets in the project dashboard (`secret()` binding), not via files in this repo. Needs to be tracked on the org's rollout checklist.
- Note: `.gitignore` currently has a `.env.*` pattern, which also matches `.env.example`. This doesn't block already-tracked files from being updated, but it's worth tightening to `.env.example` being explicitly un-ignored (`!.env.example`) if this comes up again — flagging as a minor follow-up, not blocking this PR.

## Test plan

- [ ] Confirm `.env` no longer exists in the repo/history going forward (already covered by `.gitignore`).
- [ ] Confirm `.env.example` has no real credential values.
- [ ] Confirm Railway dashboard has a real admin user/password secret configured for the deployed service (separate from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q714FWFhvmuo6m9qwttrTP)_