### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Long-form template copy for Railway (description / **Deploy and Host** sections)
 * Password Authentication (Set username & password in environment variables)
 * Railway config as code via `railway.toml`
 
+## 🏗️ Architecture
+
+```mermaid
+flowchart LR
+    Client(["🌐 Client"]) -->|HTTPS| Domain["Railway Public Domain"]
+    Domain -->|"$PORT → GF_SERVER_HTTP_PORT"| App["Container\ngrafana/grafana-oss"]
+    App --> Volume[("Volume\n/var/lib/grafana")]
+```
+
 ## Production recommendations (Railway)
 
 * Set strong `GF_SECURITY_ADMIN_PASSWORD` in Railway Variables


### PR DESCRIPTION
## Summary
- Adds a Mermaid diagram to the README showing this template's deployed architecture: Railway public domain → container (grafana-oss, `$PORT` mapped to `GF_SERVER_HTTP_PORT`) → persistent volume.
- No functional changes.

## Test plan
- [x] Verified the Mermaid block renders (fenced ```mermaid, GitHub-native rendering).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwCVWpdDxXTCW5fYFbyCRw)_